### PR TITLE
fix: support articles that have spaces in the image url

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create RSS
         run: |-
           gamingonlinux rss.xml \
-          https://lyz-code.github.io/gamingonlinux-rss/rss.xml -v
+          https://lyz-code.github.io/gamingonlinux-rss/rss.xml -v -n 200
       - name: Commit files
         run: |
           rm -r .git/hooks

--- a/pdm.lock
+++ b/pdm.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "black"
-version = "22.3.0"
+version = "22.6.0"
 requires_python = ">=3.6.2"
 summary = "The uncompromising code formatter."
 dependencies = [
@@ -113,14 +113,14 @@ dependencies = [
     "mypy-extensions>=0.4.3",
     "pathspec>=0.9.0",
     "platformdirs>=2",
-    "tomli>=1.1.0; python_version < \"3.11\"",
+    "tomli>=1.1.0; python_full_version < \"3.11.0a7\"",
     "typed-ast>=1.4.2; python_version < \"3.8\" and implementation_name == \"cpython\"",
     "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
 ]
 
 [[package]]
 name = "bleach"
-version = "5.0.0"
+version = "5.0.1"
 requires_python = ">=3.7"
 summary = "An easy safelist-based HTML-sanitizing tool."
 dependencies = [
@@ -141,7 +141,7 @@ summary = "Python package for providing Mozilla's CA Bundle."
 
 [[package]]
 name = "cffi"
-version = "1.15.0"
+version = "1.15.1"
 summary = "Foreign Function Interface for Python calling C code."
 dependencies = [
     "pycparser",
@@ -155,8 +155,8 @@ summary = "Validate configuration and produce human readable error messages."
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
-requires_python = ">=3.5.0"
+version = "2.1.0"
+requires_python = ">=3.6.0"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 
 [[package]]
@@ -177,7 +177,7 @@ summary = "Cross-platform colored terminal text."
 
 [[package]]
 name = "commitizen"
-version = "2.27.1"
+version = "2.28.0"
 requires_python = ">=3.6.2,<4.0.0"
 summary = "Python commitizen client tool"
 dependencies = [
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cryptography"
-version = "37.0.2"
+version = "37.0.4"
 requires_python = ">=3.6"
 summary = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 dependencies = [
@@ -262,8 +262,8 @@ dependencies = [
 
 [[package]]
 name = "docutils"
-version = "0.18.1"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.19"
+requires_python = ">=3.7"
 summary = "Docutils -- Python Documentation Utilities"
 
 [[package]]
@@ -301,7 +301,7 @@ summary = "Irregular methods for regular expressions"
 
 [[package]]
 name = "faker"
-version = "13.13.0"
+version = "13.14.0"
 requires_python = ">=3.6"
 summary = "Faker is a Python package that generates fake data for you."
 dependencies = [
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "flake8-bugbear"
-version = "22.4.25"
+version = "22.7.1"
 requires_python = ">=3.6"
 summary = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 dependencies = [
@@ -509,8 +509,8 @@ summary = "A flake8 extension that helps to make more readable variables names"
 
 [[package]]
 name = "flakeheaven"
-version = "1.0.1"
-requires_python = ">=3.6.2,<4.0.0"
+version = "2.0.0"
+requires_python = ">=3.7,<4.0"
 summary = "FlakeHeaven is a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool."
 dependencies = [
     "colorama",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "griffe"
-version = "0.20.0"
+version = "0.22.0"
 requires_python = ">=3.7"
 summary = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 dependencies = [
@@ -586,7 +586,7 @@ summary = "Internationalized Domain Names in Applications (IDNA)"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.4"
+version = "4.12.0"
 requires_python = ">=3.7"
 summary = "Read metadata from Python packages"
 dependencies = [
@@ -645,7 +645,7 @@ summary = "A fast and thorough lazy object proxy."
 
 [[package]]
 name = "lxml"
-version = "4.9.0"
+version = "4.9.1"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 summary = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-git-revision-date-localized-plugin"
-version = "1.0.1"
+version = "1.1.0"
 requires_python = ">=3.6"
 summary = "Mkdocs plugin that enables displaying the localized date of the last git modification of a markdown file."
 dependencies = [
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "mkdocs-material"
-version = "8.3.6"
+version = "8.3.9"
 requires_python = ">=3.7"
 summary = "Documentation that simply works"
 dependencies = [
@@ -850,8 +850,12 @@ summary = "Experimental type system extensions for programs checked with the myp
 
 [[package]]
 name = "nodeenv"
-version = "1.6.0"
+version = "1.7.0"
+requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 summary = "Node.js virtual environment builder"
+dependencies = [
+    "setuptools",
+]
 
 [[package]]
 name = "packaging"
@@ -920,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.29"
+version = "3.0.30"
 requires_python = ">=3.6.2"
 summary = "Library for building powerful interactive command lines in Python"
 dependencies = [
@@ -1136,12 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "requests"
-version = "2.28.0"
+version = "2.28.1"
 requires_python = ">=3.7, <4"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
-    "charset-normalizer~=2.0.0",
+    "charset-normalizer<3,>=2",
     "idna<4,>=2.5",
     "urllib3<1.27,>=1.21.1",
 ]
@@ -1181,6 +1185,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruamel.yaml"
+version = "0.17.21"
+requires_python = ">=3"
+summary = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+dependencies = [
+    "ruamel.yaml.clib>=0.2.6; platform_python_implementation == \"CPython\" and python_version < \"3.11\"",
+]
+
+[[package]]
+name = "ruamel.yaml.clib"
+version = "0.2.6"
+requires_python = ">=3.5"
+summary = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+
+[[package]]
 name = "ruyaml"
 version = "0.91.0"
 requires_python = ">=3.6"
@@ -1192,15 +1211,15 @@ dependencies = [
 
 [[package]]
 name = "safety"
-version = "1.10.3"
-requires_python = ">=3.5"
-summary = "Checks installed dependencies for known vulnerabilities."
+version = "2.0.0"
+summary = "Checks installed dependencies for known vulnerabilities and licenses."
 dependencies = [
-    "Click>=6.0",
+    "Click>=8.0.2",
     "dparse>=0.5.1",
-    "packaging",
+    "packaging>=21.0",
     "requests",
-    "setuptools",
+    "ruamel.yaml>=0.17.21",
+    "setuptools>=19.3",
 ]
 
 [[package]]
@@ -1215,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "setuptools"
-version = "62.4.0"
+version = "63.1.0"
 requires_python = ">=3.7"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 
@@ -1321,7 +1340,7 @@ summary = "Typing stubs for beautifulsoup4"
 
 [[package]]
 name = "typing-extensions"
-version = "4.2.0"
+version = "4.3.0"
 requires_python = ">=3.7"
 summary = "Backported and Experimental Type Hints for Python 3.7+"
 
@@ -1333,7 +1352,7 @@ summary = "HTTP library with thread-safe connection pooling, file post, and more
 
 [[package]]
 name = "virtualenv"
-version = "20.14.1"
+version = "20.15.1"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Virtual Python Environment builder"
 dependencies = [
@@ -1451,34 +1470,34 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
-"black 22.3.0" = [
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
-    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
-    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
-    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
-    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
-    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
-    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
-    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
-    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
-    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
-    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
-    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
-    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
-    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
-    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
-    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
-    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
-    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
-    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
-    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
-    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
+"black 22.6.0" = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
 ]
-"bleach 5.0.0" = [
-    {file = "bleach-5.0.0-py3-none-any.whl", hash = "sha256:08a1fe86d253b5c88c92cc3d810fd8048a16d15762e1e5b74d502256e5926aa1"},
-    {file = "bleach-5.0.0.tar.gz", hash = "sha256:c6d6cc054bdc9c83b48b8083e236e5f00f238428666d2ce2e083eaa5fd568565"},
+"bleach 5.0.1" = [
+    {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
+    {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
 ]
 "cached-property 1.5.2" = [
     {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
@@ -1488,65 +1507,79 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
-"cffi 1.15.0" = [
-    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
-    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
-    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
-    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
-    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
-    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
-    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
-    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
-    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
-    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
-    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
-    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
-    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
-    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
-    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
-    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
-    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+"cffi 1.15.1" = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
 "cfgv 3.3.1" = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
-"charset-normalizer 2.0.12" = [
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+"charset-normalizer 2.1.0" = [
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
 ]
 "click 8.1.3" = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
@@ -1556,9 +1589,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
-"commitizen 2.27.1" = [
-    {file = "commitizen-2.27.1-py3-none-any.whl", hash = "sha256:046d512c5bc795cce625211434721946f21abf713f48753f2353ec1a3e114c3f"},
-    {file = "commitizen-2.27.1.tar.gz", hash = "sha256:71a3e1fea37ced781bc440bd7d464abd5b797da8e762c1b9b632e007c2019b50"},
+"commitizen 2.28.0" = [
+    {file = "commitizen-2.28.0-py3-none-any.whl", hash = "sha256:d222f68da12a3ebcaf85c270f19eec7caacbe904349f1823deca6b5e7c2fc0f5"},
+    {file = "commitizen-2.28.0.tar.gz", hash = "sha256:8510b67e4c45131ef75114aeca5fe30b4f973b2b943457cf1667177af296192e"},
 ]
 "commonmark 0.9.1" = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -1607,29 +1640,29 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
     {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
 ]
-"cryptography 37.0.2" = [
-    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:ef15c2df7656763b4ff20a9bc4381d8352e6640cfeb95c2972c38ef508e75181"},
-    {file = "cryptography-37.0.2-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3c81599befb4d4f3d7648ed3217e00d21a9341a9a688ecdd615ff72ffbed7336"},
-    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2bd1096476aaac820426239ab534b636c77d71af66c547b9ddcd76eb9c79e004"},
-    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:31fe38d14d2e5f787e0aecef831457da6cec68e0bb09a35835b0b44ae8b988fe"},
-    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:093cb351031656d3ee2f4fa1be579a8c69c754cf874206be1d4cf3b542042804"},
-    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59b281eab51e1b6b6afa525af2bd93c16d49358404f814fe2c2410058623928c"},
-    {file = "cryptography-37.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:0cc20f655157d4cfc7bada909dc5cc228211b075ba8407c46467f63597c78178"},
-    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f8ec91983e638a9bcd75b39f1396e5c0dc2330cbd9ce4accefe68717e6779e0a"},
-    {file = "cryptography-37.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:46f4c544f6557a2fefa7ac8ac7d1b17bf9b647bd20b16decc8fbcab7117fbc15"},
-    {file = "cryptography-37.0.2-cp36-abi3-win32.whl", hash = "sha256:731c8abd27693323b348518ed0e0705713a36d79fdbd969ad968fbef0979a7e0"},
-    {file = "cryptography-37.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:471e0d70201c069f74c837983189949aa0d24bb2d751b57e26e3761f2f782b8d"},
-    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a68254dd88021f24a68b613d8c51d5c5e74d735878b9e32cc0adf19d1f10aaf9"},
-    {file = "cryptography-37.0.2-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:a7d5137e556cc0ea418dca6186deabe9129cee318618eb1ffecbd35bee55ddc1"},
-    {file = "cryptography-37.0.2-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:aeaba7b5e756ea52c8861c133c596afe93dd716cbcacae23b80bc238202dc023"},
-    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95e590dd70642eb2079d280420a888190aa040ad20f19ec8c6e097e38aa29e06"},
-    {file = "cryptography-37.0.2-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:1b9362d34363f2c71b7853f6251219298124aa4cc2075ae2932e64c91a3e2717"},
-    {file = "cryptography-37.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e53258e69874a306fcecb88b7534d61820db8a98655662a3dd2ec7f1afd9132f"},
-    {file = "cryptography-37.0.2-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:1f3bfbd611db5cb58ca82f3deb35e83af34bb8cf06043fa61500157d50a70982"},
-    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:419c57d7b63f5ec38b1199a9521d77d7d1754eb97827bbb773162073ccd8c8d4"},
-    {file = "cryptography-37.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:dc26bb134452081859aa21d4990474ddb7e863aa39e60d1592800a8865a702de"},
-    {file = "cryptography-37.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3b8398b3d0efc420e777c40c16764d6870bcef2eb383df9c6dbb9ffe12c64452"},
-    {file = "cryptography-37.0.2.tar.gz", hash = "sha256:f224ad253cc9cea7568f49077007d2263efa57396a2f2f78114066fd54b5c68e"},
+"cryptography 37.0.4" = [
+    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884"},
+    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6"},
+    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046"},
+    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5"},
+    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b"},
+    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8"},
+    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280"},
+    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3"},
+    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59"},
+    {file = "cryptography-37.0.4-cp36-abi3-win32.whl", hash = "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157"},
+    {file = "cryptography-37.0.4-cp36-abi3-win_amd64.whl", hash = "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327"},
+    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b"},
+    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"},
+    {file = "cryptography-37.0.4-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67"},
+    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d"},
+    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282"},
+    {file = "cryptography-37.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa"},
+    {file = "cryptography-37.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441"},
+    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596"},
+    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a"},
+    {file = "cryptography-37.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab"},
+    {file = "cryptography-37.0.4.tar.gz", hash = "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82"},
 ]
 "csscompressor 0.9.5" = [
     {file = "csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05"},
@@ -1653,9 +1686,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
 "dlint 0.12.0" = [
     {file = "dlint-0.12.0-py3-none-any.whl", hash = "sha256:344823d299439aa94fe276b2b3b90733026787d25713c664e137cf5f7d0645f7"},
 ]
-"docutils 0.18.1" = [
-    {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
-    {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
+"docutils 0.19" = [
+    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
+    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
 ]
 "dparse 0.5.1" = [
     {file = "dparse-0.5.1-py3-none-any.whl", hash = "sha256:e953a25e44ebb60a5c6efc2add4420c177f1d8404509da88da9729202f306994"},
@@ -1676,9 +1709,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
 "exrex 0.10.5" = [
     {file = "exrex-0.10.5.tar.gz", hash = "sha256:3fb8b18fd9832eaff8b13dc042a4f63b13c5d684ee069f70a23ddfc6bcb708f3"},
 ]
-"faker 13.13.0" = [
-    {file = "Faker-13.13.0-py3-none-any.whl", hash = "sha256:638b9c362e77bcd8212f0d1434c1940f1e8d6c336fe949add563ba0a154b6310"},
-    {file = "Faker-13.13.0.tar.gz", hash = "sha256:f192d238b3b6acb98ee85bd596258a15a171385613b30a7849e5845f8980d722"},
+"faker 13.14.0" = [
+    {file = "Faker-13.14.0-py3-none-any.whl", hash = "sha256:0297b7fc0f2458dfff8d5a92335c62fa25fb059f8cbaf7db580a0dd7177aff2e"},
+    {file = "Faker-13.14.0.tar.gz", hash = "sha256:b9f93ec97a70da79d43f497aa7b2b7d2bcd5d0c6d3ab7c102dde4193d0a38351"},
 ]
 "feedparser 6.0.10" = [
     {file = "feedparser-6.0.10-py3-none-any.whl", hash = "sha256:79c257d526d13b944e965f6095700587f27388e50ea16fd245babe4dfae7024f"},
@@ -1704,9 +1737,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "flake8_annotations_complexity-0.0.7-py3-none-any.whl", hash = "sha256:a1410f5b964927032471ce99932d1670d28ea323b50400b45cc14575be070508"},
     {file = "flake8_annotations_complexity-0.0.7.tar.gz", hash = "sha256:2ecd93375e3dee0d4e11e476087a52fa985c47bc049015ff04a9de38fc0c4dfd"},
 ]
-"flake8-bugbear 22.4.25" = [
-    {file = "flake8_bugbear-22.4.25-py3-none-any.whl", hash = "sha256:ec374101cddf65bd7a96d393847d74e58d3b98669dbf9768344c39b6290e8bd6"},
-    {file = "flake8-bugbear-22.4.25.tar.gz", hash = "sha256:f7c080563fca75ee6b205d06b181ecba22b802babb96b0b084cc7743d6908a55"},
+"flake8-bugbear 22.7.1" = [
+    {file = "flake8_bugbear-22.7.1-py3-none-any.whl", hash = "sha256:db5d7a831ef4412a224b26c708967ff816818cabae415e76b8c58df156c4b8e5"},
+    {file = "flake8-bugbear-22.7.1.tar.gz", hash = "sha256:e450976a07e4f9d6c043d4f72b17ec1baf717fe37f7997009c8ae58064f88305"},
 ]
 "flake8-comprehensions 3.10.0" = [
     {file = "flake8_comprehensions-3.10.0-py3-none-any.whl", hash = "sha256:dad454fd3d525039121e98fa1dd90c46bc138708196a4ebbc949ad3c859adedb"},
@@ -1767,9 +1800,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "flake8_variables_names-0.0.5-py3-none-any.whl", hash = "sha256:e3277031696bbe10b5132b49938cde1d70fcae9561533b7bd7ab8e69cb27addb"},
     {file = "flake8_variables_names-0.0.5.tar.gz", hash = "sha256:30133e14ee2300e13a60393a00f74d98110c76070ac67d1ab91606f02824a7e1"},
 ]
-"flakeheaven 1.0.1" = [
-    {file = "flakeheaven-1.0.1-py3-none-any.whl", hash = "sha256:00bc43b63c35b4dd9b662251a557659dd334a7f233693a3d6409a18ceed3d822"},
-    {file = "flakeheaven-1.0.1.tar.gz", hash = "sha256:7cc00df80e3c7f3188ea6525e3040c47968547b453ddc0bfa27389b333124463"},
+"flakeheaven 2.0.0" = [
+    {file = "flakeheaven-2.0.0-py3-none-any.whl", hash = "sha256:e25be0838eddb500f9ad1852e3f7bb541ed97bc896eaa3b491abb81e2112ca65"},
+    {file = "flakeheaven-2.0.0.tar.gz", hash = "sha256:843a594059c7fdab2f01bce5c872717ac0b8b54cc0311283e66c80eac5031551"},
 ]
 "freezegun 1.2.1" = [
     {file = "freezegun-1.2.1-py3-none-any.whl", hash = "sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09"},
@@ -1787,9 +1820,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "GitPython-3.1.27-py3-none-any.whl", hash = "sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d"},
     {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
 ]
-"griffe 0.20.0" = [
-    {file = "griffe-0.20.0-py3-none-any.whl", hash = "sha256:899e0c9c09baf22b31de1c969a03edaf0ddf72d0a7183df8de746b6c26ed62f4"},
-    {file = "griffe-0.20.0.tar.gz", hash = "sha256:bf181de6e661c0d2a229c1dc7e90db0def280ee3a89c6829fcc1695baee65f7f"},
+"griffe 0.22.0" = [
+    {file = "griffe-0.22.0-py3-none-any.whl", hash = "sha256:65c94cba634d6ad397c495b04ed5fd3f06d9b16c4f9f78bd63be9ea34d6b7113"},
+    {file = "griffe-0.22.0.tar.gz", hash = "sha256:a3c25a2b7bf729ecee7cd455b4eff548f01c620b8f58a8097a800caad221f12e"},
 ]
 "htmlmin 0.1.12" = [
     {file = "htmlmin-0.1.12.tar.gz", hash = "sha256:50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178"},
@@ -1802,9 +1835,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-"importlib-metadata 4.11.4" = [
-    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
-    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
+"importlib-metadata 4.12.0" = [
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
 "iniconfig 1.1.1" = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1868,70 +1901,78 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
 ]
-"lxml 4.9.0" = [
-    {file = "lxml-4.9.0-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:b5031d151d6147eac53366d6ec87da84cd4d8c5e80b1d9948a667a7164116e39"},
-    {file = "lxml-4.9.0-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5d52e1173f52020392f593f87a6af2d4055dd800574a5cb0af4ea3878801d307"},
-    {file = "lxml-4.9.0-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3af00ee88376022589ceeb8170eb67dacf5f7cd625ea59fa0977d719777d4ae8"},
-    {file = "lxml-4.9.0-cp27-cp27m-win32.whl", hash = "sha256:1057356b808d149bc14eb8f37bb89129f237df488661c1e0fc0376ca90e1d2c3"},
-    {file = "lxml-4.9.0-cp27-cp27m-win_amd64.whl", hash = "sha256:f6d23a01921b741774f35e924d418a43cf03eca1444f3fdfd7978d35a5aaab8b"},
-    {file = "lxml-4.9.0-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:56e19fb6e4b8bd07fb20028d03d3bc67bcc0621347fbde64f248e44839771756"},
-    {file = "lxml-4.9.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4cd69bca464e892ea4ed544ba6a7850aaff6f8d792f8055a10638db60acbac18"},
-    {file = "lxml-4.9.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:94b181dd2777890139e49a5336bf3a9a3378ce66132c665fe8db4e8b7683cde2"},
-    {file = "lxml-4.9.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:607224ffae9a0cf0a2f6e14f5f6bce43e83a6fbdaa647891729c103bdd6a5593"},
-    {file = "lxml-4.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:11d62c97ceff9bab94b6b29c010ea5fb6831743459bb759c917f49ba75601cd0"},
-    {file = "lxml-4.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:70a198030d26f5e569367f0f04509b63256faa76a22886280eea69a4f535dd40"},
-    {file = "lxml-4.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3cf816aed8125cfc9e6e5c6c31ff94278320d591bd7970c4a0233bee0d1c8790"},
-    {file = "lxml-4.9.0-cp310-cp310-win32.whl", hash = "sha256:65b3b5f12c6fb5611e79157214f3cd533083f9b058bf2fc8a1c5cc5ee40fdc5a"},
-    {file = "lxml-4.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:0aa4cce579512c33373ca4c5e23c21e40c1aa1a33533a75e51b654834fd0e4f2"},
-    {file = "lxml-4.9.0-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:63419db39df8dc5564f6f103102c4665f7e4d9cb64030e98cf7a74eae5d5760d"},
-    {file = "lxml-4.9.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d8e5021e770b0a3084c30dda5901d5fce6d4474feaf0ced8f8e5a82702502fbb"},
-    {file = "lxml-4.9.0-cp35-cp35m-win32.whl", hash = "sha256:f17b9df97c5ecdfb56c5e85b3c9df9831246df698f8581c6e111ac664c7c656e"},
-    {file = "lxml-4.9.0-cp35-cp35m-win_amd64.whl", hash = "sha256:75da29a0752c8f2395df0115ac1681cefbdd4418676015be8178b733704cbff2"},
-    {file = "lxml-4.9.0-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:e4d020ecf3740b7312bacab2cb966bb720fd4d3490562d373b4ad91dd1857c0d"},
-    {file = "lxml-4.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:b71c52d69b91af7d18c13aef1b0cc3baee36b78607c711eb14a52bf3aa7c815e"},
-    {file = "lxml-4.9.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28cf04a1a38e961d4a764d2940af9b941b66263ed5584392ef875ee9c1e360a3"},
-    {file = "lxml-4.9.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:915ecf7d486df17cc65aeefdb680d5ad4390cc8c857cf8db3fe241ed234f856a"},
-    {file = "lxml-4.9.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e564d5a771b4015f34166a05ea2165b7e283635c41b1347696117f780084b46d"},
-    {file = "lxml-4.9.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c2a57755e366e0ac7ebdb3e9207f159c3bf1afed02392ab18453ce81f5ee92ee"},
-    {file = "lxml-4.9.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:00f3a6f88fd5f4357844dd91a1abac5f466c6799f1b7f1da2df6665253845b11"},
-    {file = "lxml-4.9.0-cp36-cp36m-win32.whl", hash = "sha256:9093a359a86650a3dbd6532c3e4d21a6f58ba2cb60d0e72db0848115d24c10ba"},
-    {file = "lxml-4.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d1690c4d37674a5f0cdafbc5ed7e360800afcf06928c2a024c779c046891bf09"},
-    {file = "lxml-4.9.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:6af7f51a6010748fc1bb71917318d953c9673e4ae3f6d285aaf93ef5b2eb11c1"},
-    {file = "lxml-4.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:eabdbe04ee0a7e760fa6cd9e799d2b020d098c580ba99107d52e1e5e538b1ecb"},
-    {file = "lxml-4.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b1e22f3ee4d75ca261b6bffbf64f6f178cb194b1be3191065a09f8d98828daa9"},
-    {file = "lxml-4.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:53b0410b220766321759f7f9066da67b1d0d4a7f6636a477984cbb1d98483955"},
-    {file = "lxml-4.9.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d76da27f5e3e9bc40eba6ed7a9e985f57547e98cf20521d91215707f2fb57e0f"},
-    {file = "lxml-4.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:686565ac77ff94a8965c11829af253d9e2ce3bf0d9225b1d2eb5c4d4666d0dca"},
-    {file = "lxml-4.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b62d1431b4c40cda43cc986f19b8c86b1d2ae8918cfc00f4776fdf070b65c0c4"},
-    {file = "lxml-4.9.0-cp37-cp37m-win32.whl", hash = "sha256:4becd16750ca5c2a1b1588269322b2cebd10c07738f336c922b658dbab96a61c"},
-    {file = "lxml-4.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e35a298691b9e10e5a5631f8f0ba605b30ebe19208dc8f58b670462f53753641"},
-    {file = "lxml-4.9.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:aa7447bf7c1a15ef24e2b86a277b585dd3f055e8890ac7f97374d170187daa97"},
-    {file = "lxml-4.9.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:612ef8f2795a89ba3a1d4c8c1af84d8453fd53ee611aa5ad460fdd2cab426fc2"},
-    {file = "lxml-4.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:1bfb791a8fcdbf55d1d41b8be940393687bec0e9b12733f0796668086d1a23ff"},
-    {file = "lxml-4.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:024684e0c5cfa121c22140d3a0898a3a9b2ea0f0fd2c229b6658af4bdf1155e5"},
-    {file = "lxml-4.9.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:81c29c8741fa07ecec8ec7417c3d8d1e2f18cf5a10a280f4e1c3f8c3590228b2"},
-    {file = "lxml-4.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6467626fa74f96f4d80fc6ec2555799e97fff8f36e0bfc7f67769f83e59cff40"},
-    {file = "lxml-4.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9cae837b988f44925d14d048fa6a8c54f197c8b1223fd9ee9c27084f84606143"},
-    {file = "lxml-4.9.0-cp38-cp38-win32.whl", hash = "sha256:5a49ad78543925e1a4196e20c9c54492afa4f1502c2a563f73097e2044c75190"},
-    {file = "lxml-4.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:bb7c1b029e54e26e01b1d1d912fc21abb65650d16ea9a191d026def4ed0859ed"},
-    {file = "lxml-4.9.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d0d03b9636f1326772e6854459728676354d4c7731dae9902b180e2065ba3da6"},
-    {file = "lxml-4.9.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:9af19eb789d674b59a9bee5005779757aab857c40bf9cc313cb01eafac55ce55"},
-    {file = "lxml-4.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:dd00d28d1ab5fa7627f5abc957f29a6338a7395b724571a8cbff8fbed83aaa82"},
-    {file = "lxml-4.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:754a1dd04bff8a509a31146bd8f3a5dc8191a8694d582dd5fb71ff09f0722c22"},
-    {file = "lxml-4.9.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b7679344f2270840dc5babc9ccbedbc04f7473c1f66d4676bb01680c0db85bcc"},
-    {file = "lxml-4.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d882c2f3345261e898b9f604be76b61c901fbfa4ac32e3f51d5dc1edc89da3cb"},
-    {file = "lxml-4.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4e97c8fc761ad63909198acc892f34c20f37f3baa2c50a62d5ec5d7f1efc68a1"},
-    {file = "lxml-4.9.0-cp39-cp39-win32.whl", hash = "sha256:cf9ec915857d260511399ab87e1e70fa13d6b2972258f8e620a3959468edfc32"},
-    {file = "lxml-4.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:1254a79f8a67a3908de725caf59eae62d86738f6387b0a34b32e02abd6ae73db"},
-    {file = "lxml-4.9.0-pp37-pypy37_pp73-macosx_10_15_x86_64.whl", hash = "sha256:03370ec37fe562238d385e2c53089076dee53aabf8325cab964fdb04a9130fa0"},
-    {file = "lxml-4.9.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f386def57742aacc3d864169dfce644a8c396f95aa35b41b69df53f558d56dd0"},
-    {file = "lxml-4.9.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ea3f2e9eb41f973f73619e88bf7bd950b16b4c2ce73d15f24a11800ce1eaf276"},
-    {file = "lxml-4.9.0-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2d10659e6e5c53298e6d718fd126e793285bff904bb71d7239a17218f6a197b7"},
-    {file = "lxml-4.9.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:fcdf70191f0d1761d190a436db06a46f05af60e1410e1507935f0332280c9268"},
-    {file = "lxml-4.9.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:2b9c2341d96926b0d0e132e5c49ef85eb53fa92ae1c3a70f9072f3db0d32bc07"},
-    {file = "lxml-4.9.0-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:615886ee84b6f42f1bdf1852a9669b5fe3b96b6ff27f1a7a330b67ad9911200a"},
-    {file = "lxml-4.9.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:94f2e45b054dd759bed137b6e14ae8625495f7d90ddd23cf62c7a68f72b62656"},
-    {file = "lxml-4.9.0.tar.gz", hash = "sha256:520461c36727268a989790aef08884347cd41f2d8ae855489ccf40b50321d8d7"},
+"lxml 4.9.1" = [
+    {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c62e8dd9754b7debda0c5ba59d34509c4688f853588d75b53c3791983faa96fc"},
+    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21fb3d24ab430fc538a96e9fbb9b150029914805d551deeac7d7822f64631dfc"},
+    {file = "lxml-4.9.1-cp27-cp27m-win32.whl", hash = "sha256:86e92728ef3fc842c50a5cb1d5ba2bc66db7da08a7af53fb3da79e202d1b2cd3"},
+    {file = "lxml-4.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4cfbe42c686f33944e12f45a27d25a492cc0e43e1dc1da5d6a87cbcaf2e95627"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dad7b164905d3e534883281c050180afcf1e230c3d4a54e8038aa5cfcf312b84"},
+    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a614e4afed58c14254e67862456d212c4dcceebab2eaa44d627c2ca04bf86837"},
+    {file = "lxml-4.9.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:49a866923e69bc7da45a0565636243707c22752fc38f6b9d5c8428a86121022c"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d9fc0bf3ff86c17348dfc5d322f627d78273eba545db865c3cd14b3f19e57fa5"},
+    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e5f66bdf0976ec667fc4594d2812a00b07ed14d1b44259d19a41ae3fff99f2b8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8"},
+    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8caf4d16b31961e964c62194ea3e26a0e9561cdf72eecb1781458b67ec83423d"},
+    {file = "lxml-4.9.1-cp310-cp310-win32.whl", hash = "sha256:4780677767dd52b99f0af1f123bc2c22873d30b474aa0e2fc3fe5e02217687c7"},
+    {file = "lxml-4.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:b122a188cd292c4d2fcd78d04f863b789ef43aa129b233d7c9004de08693728b"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:be9eb06489bc975c38706902cbc6888f39e946b81383abc2838d186f0e8b6a9d"},
+    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f1be258c4d3dc609e654a1dc59d37b17d7fef05df912c01fc2e15eb43a9735f3"},
+    {file = "lxml-4.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:927a9dd016d6033bc12e0bf5dee1dde140235fc8d0d51099353c76081c03dc29"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9232b09f5efee6a495a99ae6824881940d6447debe272ea400c02e3b68aad85d"},
+    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:04da965dfebb5dac2619cb90fcf93efdb35b3c6994fea58a157a834f2f94b318"},
+    {file = "lxml-4.9.1-cp35-cp35m-win32.whl", hash = "sha256:4d5bae0a37af799207140652a700f21a85946f107a199bcb06720b13a4f1f0b7"},
+    {file = "lxml-4.9.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4878e667ebabe9b65e785ac8da4d48886fe81193a84bbe49f12acff8f7a383a4"},
+    {file = "lxml-4.9.1-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:1355755b62c28950f9ce123c7a41460ed9743c699905cbe664a5bcc5c9c7c7fb"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:bcaa1c495ce623966d9fc8a187da80082334236a2a1c7e141763ffaf7a405067"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eafc048ea3f1b3c136c71a86db393be36b5b3d9c87b1c25204e7d397cee9536"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:13c90064b224e10c14dcdf8086688d3f0e612db53766e7478d7754703295c7c8"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206a51077773c6c5d2ce1991327cda719063a47adc02bd703c56a662cdb6c58b"},
+    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e8f0c9d65da595cfe91713bc1222af9ecabd37971762cb830dea2fc3b3bb2acf"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8f0a4d179c9a941eb80c3a63cdb495e539e064f8054230844dcf2fcb812b71d3"},
+    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:830c88747dce8a3e7525defa68afd742b4580df6aa2fdd6f0855481e3994d391"},
+    {file = "lxml-4.9.1-cp36-cp36m-win32.whl", hash = "sha256:1e1cf47774373777936c5aabad489fef7b1c087dcd1f426b621fda9dcc12994e"},
+    {file = "lxml-4.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:5974895115737a74a00b321e339b9c3f45c20275d226398ae79ac008d908bff7"},
+    {file = "lxml-4.9.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:1423631e3d51008871299525b541413c9b6c6423593e89f9c4cfbe8460afc0a2"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:2aaf6a0a6465d39b5ca69688fce82d20088c1838534982996ec46633dc7ad6cc"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:9f36de4cd0c262dd9927886cc2305aa3f2210db437aa4fed3fb4940b8bf4592c"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae06c1e4bc60ee076292e582a7512f304abdf6c70db59b56745cca1684f875a4"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:57e4d637258703d14171b54203fd6822fda218c6c2658a7d30816b10995f29f3"},
+    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d279033bf614953c3fc4a0aa9ac33a21e8044ca72d4fa8b9273fe75359d5cca"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a60f90bba4c37962cbf210f0188ecca87daafdf60271f4c6948606e4dabf8785"},
+    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6ca2264f341dd81e41f3fffecec6e446aa2121e0b8d026fb5130e02de1402785"},
+    {file = "lxml-4.9.1-cp37-cp37m-win32.whl", hash = "sha256:27e590352c76156f50f538dbcebd1925317a0f70540f7dc8c97d2931c595783a"},
+    {file = "lxml-4.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:eea5d6443b093e1545ad0210e6cf27f920482bfcf5c77cdc8596aec73523bb7e"},
+    {file = "lxml-4.9.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f05251bbc2145349b8d0b77c0d4e5f3b228418807b1ee27cefb11f69ed3d233b"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:487c8e61d7acc50b8be82bda8c8d21d20e133c3cbf41bd8ad7eb1aaeb3f07c97"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d1a92d8e90b286d491e5626af53afef2ba04da33e82e30744795c71880eaa21"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:b570da8cd0012f4af9fa76a5635cd31f707473e65a5a335b186069d5c7121ff2"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ef87fca280fb15342726bd5f980f6faf8b84a5287fcc2d4962ea8af88b35130"},
+    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:93e414e3206779ef41e5ff2448067213febf260ba747fc65389a3ddaa3fb8715"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6653071f4f9bac46fbc30f3c7838b0e9063ee335908c5d61fb7a4a86c8fd2036"},
+    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:32a73c53783becdb7eaf75a2a1525ea8e49379fb7248c3eeefb9412123536387"},
+    {file = "lxml-4.9.1-cp38-cp38-win32.whl", hash = "sha256:1a7c59c6ffd6ef5db362b798f350e24ab2cfa5700d53ac6681918f314a4d3b94"},
+    {file = "lxml-4.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:1436cf0063bba7888e43f1ba8d58824f085410ea2025befe81150aceb123e345"},
+    {file = "lxml-4.9.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4beea0f31491bc086991b97517b9683e5cfb369205dac0148ef685ac12a20a67"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41fb58868b816c202e8881fd0f179a4644ce6e7cbbb248ef0283a34b73ec73bb"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:bd34f6d1810d9354dc7e35158aa6cc33456be7706df4420819af6ed966e85448"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:edffbe3c510d8f4bf8640e02ca019e48a9b72357318383ca60e3330c23aaffc7"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d949f53ad4fc7cf02c44d6678e7ff05ec5f5552b235b9e136bd52e9bf730b91"},
+    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:079b68f197c796e42aa80b1f739f058dcee796dc725cc9a1be0cdb08fc45b000"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c3a88d20e4fe4a2a4a84bf439a5ac9c9aba400b85244c63a1ab7088f85d9d25"},
+    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4e285b5f2bf321fc0857b491b5028c5f276ec0c873b985d58d7748ece1d770dd"},
+    {file = "lxml-4.9.1-cp39-cp39-win32.whl", hash = "sha256:ef72013e20dd5ba86a8ae1aed7f56f31d3374189aa8b433e7b12ad182c0d2dfb"},
+    {file = "lxml-4.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:10d2017f9150248563bb579cd0d07c61c58da85c922b780060dcc9a3aa9f432d"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538747a9d7827ce3e16a8fdd201a99e661c7dee3c96c885d8ecba3c35d1032c"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0645e934e940107e2fdbe7c5b6fb8ec6232444260752598bc4d09511bd056c0b"},
+    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6daa662aba22ef3258934105be2dd9afa5bb45748f4f702a3b39a5bf53a1f4dc"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:603a464c2e67d8a546ddaa206d98e3246e5db05594b97db844c2f0a1af37cf5b"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c4b2e0559b68455c085fb0f6178e9752c4be3bba104d6e881eb5573b399d1eb2"},
+    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0f3f0059891d3254c7b5fb935330d6db38d6519ecd238ca4fce93c234b4a0f73"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c852b1530083a620cb0de5f3cd6826f19862bafeaf77586f1aef326e49d95f0c"},
+    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:287605bede6bd36e930577c5925fcea17cb30453d96a7b4c63c14a257118dbb9"},
+    {file = "lxml-4.9.1.tar.gz", hash = "sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"},
 ]
 "maison 1.4.0" = [
     {file = "maison-1.4.0-py3-none-any.whl", hash = "sha256:591a6ffe972558685cf2c3fdbff3dfa1e6b57a0227c50d387426ab9745e5939b"},
@@ -2006,17 +2047,17 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "mkdocs_autorefs-0.4.1-py3-none-any.whl", hash = "sha256:a2248a9501b29dc0cc8ba4c09f4f47ff121945f6ce33d760f145d6f89d313f5b"},
     {file = "mkdocs-autorefs-0.4.1.tar.gz", hash = "sha256:70748a7bd025f9ecd6d6feeba8ba63f8e891a1af55f48e366d6d6e78493aba84"},
 ]
-"mkdocs-git-revision-date-localized-plugin 1.0.1" = [
-    {file = "mkdocs_git_revision_date_localized_plugin-1.0.1-py3-none-any.whl", hash = "sha256:ffcf206b5108d9f729af6cd42377d2e0e25c080817fdad0119549ac924b526f3"},
-    {file = "mkdocs-git-revision-date-localized-plugin-1.0.1.tar.gz", hash = "sha256:f3e020b445e7b4fb4e58ccd46b07adecbca0f85ac1659e1a63e38b8779c81ba7"},
+"mkdocs-git-revision-date-localized-plugin 1.1.0" = [
+    {file = "mkdocs_git_revision_date_localized_plugin-1.1.0-py3-none-any.whl", hash = "sha256:4ba0e49abea3e9f6ee26e2623ff7283873da657471c61f1d0cfbb986f403316d"},
+    {file = "mkdocs-git-revision-date-localized-plugin-1.1.0.tar.gz", hash = "sha256:38517e2084229da1a1b9460e846c2748d238c2d79efd405d1b9174a87bd81d79"},
 ]
 "mkdocs-htmlproofer-plugin 0.8.0" = [
     {file = "mkdocs_htmlproofer_plugin-0.8.0-py3-none-any.whl", hash = "sha256:914fa007df4182e22440c5d23670eba36392e7f58f99de728f3b1d7cfb4847c6"},
     {file = "mkdocs-htmlproofer-plugin-0.8.0.tar.gz", hash = "sha256:48db49ede2d94939b4773feaa8159f88803bf5edd87ea99c78665f8d61107651"},
 ]
-"mkdocs-material 8.3.6" = [
-    {file = "mkdocs_material-8.3.6-py2.py3-none-any.whl", hash = "sha256:01f3fbab055751b3b75a64b538e86b9ce0c6a0f8d43620f6287dfa16534443e5"},
-    {file = "mkdocs-material-8.3.6.tar.gz", hash = "sha256:be8f95c0dfb927339b55b2cc066423dc0b381be9828ff74a5b02df979a859b66"},
+"mkdocs-material 8.3.9" = [
+    {file = "mkdocs_material-8.3.9-py2.py3-none-any.whl", hash = "sha256:263f2721f3abe533b61f7c8bed435a0462620912742c919821ac2d698b4bfe67"},
+    {file = "mkdocs-material-8.3.9.tar.gz", hash = "sha256:dc82b667d2a83f0de581b46a6d0949732ab77e7638b87ea35b770b33bc02e75a"},
 ]
 "mkdocs-material-extensions 1.0.3" = [
     {file = "mkdocs_material_extensions-1.0.3-py3-none-any.whl", hash = "sha256:a82b70e533ce060b2a5d9eb2bc2e1be201cf61f901f93704b4acf6e3d5983a44"},
@@ -2067,9 +2108,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
-"nodeenv 1.6.0" = [
-    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
-    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+"nodeenv 1.7.0" = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
 ]
 "packaging 21.3" = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -2103,9 +2144,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "pre_commit-2.19.0-py2.py3-none-any.whl", hash = "sha256:10c62741aa5704faea2ad69cb550ca78082efe5697d6f04e5710c3c229afdd10"},
     {file = "pre_commit-2.19.0.tar.gz", hash = "sha256:4233a1e38621c87d9dda9808c6606d7e7ba0e087cd56d3fe03202a01d2919615"},
 ]
-"prompt-toolkit 3.0.29" = [
-    {file = "prompt_toolkit-3.0.29-py3-none-any.whl", hash = "sha256:62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752"},
-    {file = "prompt_toolkit-3.0.29.tar.gz", hash = "sha256:bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7"},
+"prompt-toolkit 3.0.30" = [
+    {file = "prompt_toolkit-3.0.30-py3-none-any.whl", hash = "sha256:d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289"},
+    {file = "prompt_toolkit-3.0.30.tar.gz", hash = "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0"},
 ]
 "py 1.11.0" = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -2267,9 +2308,9 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "readme_renderer-35.0-py3-none-any.whl", hash = "sha256:73b84905d091c31f36e50b4ae05ae2acead661f6a09a9abb4df7d2ddcdb6a698"},
     {file = "readme_renderer-35.0.tar.gz", hash = "sha256:a727999acfc222fc21d82a12ed48c957c4989785e5865807c65a487d21677497"},
 ]
-"requests 2.28.0" = [
-    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
-    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
+"requests 2.28.1" = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 "requests-mock 1.9.3" = [
     {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
@@ -2287,21 +2328,52 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "rich-12.4.4-py3-none-any.whl", hash = "sha256:d2bbd99c320a2532ac71ff6a3164867884357da3e3301f0240090c5d2fdac7ec"},
     {file = "rich-12.4.4.tar.gz", hash = "sha256:4c586de507202505346f3e32d1363eb9ed6932f0c2f63184dea88983ff4971e2"},
 ]
+"ruamel.yaml 0.17.21" = [
+    {file = "ruamel.yaml-0.17.21-py3-none-any.whl", hash = "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7"},
+    {file = "ruamel.yaml-0.17.21.tar.gz", hash = "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"},
+]
+"ruamel.yaml.clib 0.2.6" = [
+    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0"},
+    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7"},
+    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win32.whl", hash = "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee"},
+    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de"},
+    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751"},
+    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527"},
+    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win32.whl", hash = "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5"},
+    {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win_amd64.whl", hash = "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"},
+    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502"},
+    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78"},
+    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win32.whl", hash = "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94"},
+    {file = "ruamel.yaml.clib-0.2.6-cp36-cp36m-win_amd64.whl", hash = "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468"},
+    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd"},
+    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99"},
+    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win32.whl", hash = "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb"},
+    {file = "ruamel.yaml.clib-0.2.6-cp37-cp37m-win_amd64.whl", hash = "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe"},
+    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233"},
+    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84"},
+    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win32.whl", hash = "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b"},
+    {file = "ruamel.yaml.clib-0.2.6-cp38-cp38-win_amd64.whl", hash = "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277"},
+    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed"},
+    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0"},
+    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win32.whl", hash = "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104"},
+    {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win_amd64.whl", hash = "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7"},
+    {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
+]
 "ruyaml 0.91.0" = [
     {file = "ruyaml-0.91.0-py3-none-any.whl", hash = "sha256:50e0ee3389c77ad340e209472e0effd41ae0275246df00cdad0a067532171755"},
     {file = "ruyaml-0.91.0.tar.gz", hash = "sha256:6ce9de9f4d082d696d3bde264664d1bcdca8f5a9dff9d1a1f1a127969ab871ab"},
 ]
-"safety 1.10.3" = [
-    {file = "safety-1.10.3-py2.py3-none-any.whl", hash = "sha256:5f802ad5df5614f9622d8d71fedec2757099705c2356f862847c58c6dfe13e84"},
-    {file = "safety-1.10.3.tar.gz", hash = "sha256:30e394d02a20ac49b7f65292d19d38fa927a8f9582cdfd3ad1adbbc66c641ad5"},
+"safety 2.0.0" = [
+    {file = "safety-2.0.0-py3-none-any.whl", hash = "sha256:77cebdd128ce47b941e68a1b3bbc29fbbd2b9e98d11f179c5def64c1d05da295"},
+    {file = "safety-2.0.0.tar.gz", hash = "sha256:d739d00a9e4203cfaba34540c822a73ca1d327159ed7776b3dce09391f81c35d"},
 ]
 "secretstorage 3.3.2" = [
     {file = "SecretStorage-3.3.2-py3-none-any.whl", hash = "sha256:755dc845b6ad76dcbcbc07ea3da75ae54bb1ea529eb72d15f83d26499a5df319"},
     {file = "SecretStorage-3.3.2.tar.gz", hash = "sha256:0a8eb9645b320881c222e827c26f4cfcf55363e8b374a021981ef886657a912f"},
 ]
-"setuptools 62.4.0" = [
-    {file = "setuptools-62.4.0-py3-none-any.whl", hash = "sha256:5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77"},
-    {file = "setuptools-62.4.0.tar.gz", hash = "sha256:bf8a748ac98b09d32c9a64a995a6b25921c96cc5743c1efa82763ba80ff54e91"},
+"setuptools 63.1.0" = [
+    {file = "setuptools-63.1.0-py3-none-any.whl", hash = "sha256:db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65"},
+    {file = "setuptools-63.1.0.tar.gz", hash = "sha256:16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793"},
 ]
 "sgmllib3k 1.0.0" = [
     {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
@@ -2383,17 +2455,17 @@ content_hash = "sha256:23854e0fec07f0029787882ec126beb0bb4bc4b24864ff985b3bfdb9d
     {file = "types_beautifulsoup4-4.11.2-py3-none-any.whl", hash = "sha256:2838757b9f321ad7b781c336c1779a1c5b2f1966b83d125b872102be940a5a0f"},
     {file = "types-beautifulsoup4-4.11.2.tar.gz", hash = "sha256:7c45224fd47d39d822efc72838f58e43d2da7fa744107e772ecf779ff6190f2d"},
 ]
-"typing-extensions 4.2.0" = [
-    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
-    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+"typing-extensions 4.3.0" = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 "urllib3 1.26.9" = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
-"virtualenv 20.14.1" = [
-    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
-    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+"virtualenv 20.15.1" = [
+    {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},
+    {file = "virtualenv-20.15.1.tar.gz", hash = "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4"},
 ]
 "watchdog 2.1.9" = [
     {file = "watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330"},

--- a/src/gamingonlinux_rss/adapters/__init__.py
+++ b/src/gamingonlinux_rss/adapters/__init__.py
@@ -1,5 +1,0 @@
-"""Module to store the functions shared by the different adapters."""
-
-import logging
-
-log = logging.getLogger(__name__)

--- a/src/gamingonlinux_rss/templates/rss.xml.j2
+++ b/src/gamingonlinux_rss/templates/rss.xml.j2
@@ -24,7 +24,7 @@
       <description>{{ article.content }}</description>
       <link>{{ article.url }}</link>
       <guid isPermaLink="true">{{ article.url }}</guid>
-      <pubDate>{{ article.created_at }}</pubDate>
+      <pubDate>{{ article.published_at }}</pubDate>
       <enclosure url="{{ article.image }}" type="image/jpeg"/>
       {% for tag in article.tags %}
       <category>{{ tag }}</category>

--- a/tests/assets/homepage-with-space-in-article-image-url.html
+++ b/tests/assets/homepage-with-space-in-article-image-url.html
@@ -1,0 +1,767 @@
+
+<!DOCTYPE html>
+<html lang="en" >
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<title>Linux, SteamOS, Steam Deck gaming - page 2 | GamingOnLinux</title>
+<script data-cfasync="false">var website_theme='light';if(document.documentElement.hasAttribute("data-theme")){website_theme=document.documentElement.getAttribute("data-theme")}else{if(localStorage.getItem("theme")){if(localStorage.getItem("theme")=="dark"){website_theme="dark"}}else if(window.matchMedia("(prefers-color-scheme: dark)").matches){website_theme="dark"}if(website_theme=="dark"){document.documentElement.setAttribute("data-theme","dark")}}</script>
+<noscript><style type="text/css" media="screen">.unhide-js-off { display: block !important; }</style></noscript>
+<meta name="description" content="Linux Gaming, SteamOS and Steam Deck gaming. Covering Linux Gaming News, Linux Games, SteamOS, Indie Game Reviews, Steam Play Proton and more." />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta property="og:site_name" content="GamingOnLinux" />
+<link rel="canonical" href="https://www.gamingonlinux.com/">
+<meta name="theme-color" content="#222">
+<link href="https://www.gamingonlinux.com/templates/default/images/favicons/favicon.ico" rel="shortcut icon" type="image/x-icon" />
+<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+<script type="application/ld+json">
+{
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	"name": "GamingOnLinux",
+	"url": "https://www.gamingonlinux.com",
+	"logo": {
+        "@type": "ImageObject",
+        "url": "https://www.gamingonlinux.com/templates/default/images/logos/icon_large.png",
+        "width": 349,
+        "height": 420
+    },
+	"sameAs": [
+        "https://www.facebook.com/gamingonlinux",
+        "https://twitter.com/gamingonlinux"
+    ],
+    "keywords": [
+        "Linux Gaming",
+        "Gaming On Linux",
+        "SteamOS",
+		"Steam Deck",
+		"Linux Games",
+		"linux gaming news"
+    ]
+}</script><meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@gamingonlinux">
+<meta name="twitter:title" content="GamingOnLinux">
+<meta name="twitter:description" content="Linux Gaming, SteamOS and Steam Deck gaming. Covering Linux Gaming News, Linux Games, SteamOS, Indie Game Reviews, Steam Play Proton and more.">
+<meta name="twitter:image" content="https://www.gamingonlinux.com/templates/default/images/logos/twitter_card_icon.png">
+<meta name="twitter:image:src" content="https://www.gamingonlinux.com/templates/default/images/logos/twitter_card_icon.png">
+
+<!--JS Files-->
+
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1e7f919ec8e642738136e35ebc0db244"}'></script><!-- End Cloudflare Web Analytics -->
+
+
+<link rel="preload" as="script" href="https://www.gamingonlinux.com/includes/jscripts/jquery-3.4.1.min.js">
+<script src="https://www.gamingonlinux.com/includes/jscripts/jquery-3.4.1.min.js"></script>
+<!--Apple Devices-->
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-180x180.png" />
+<link rel="apple-touch-icon" sizes="152x152" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-152x152.png" />
+<link rel="apple-touch-icon" sizes="144x144" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-144x144.png" />
+<link rel="apple-touch-icon" sizes="120x120" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-120x120.png" />
+<link rel="apple-touch-icon" sizes="114x114" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-114x114.png" />
+<link rel="apple-touch-icon" sizes="76x76" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-76x76.png" />
+<link rel="apple-touch-icon" sizes="72x72" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-72x72.png" />
+<link rel="apple-touch-icon" sizes="60x60" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-60x60.png" />
+<link rel="apple-touch-icon" sizes="57x57" href="https://www.gamingonlinux.com/templates/default/images/favicons/apple-touch-icon-57x57.png" />
+<!--Windows 8 Metro UI-->
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-TileImage" content="https://www.gamingonlinux.com/templates/default/images/favicons/mstile-144x144.png">
+<meta name="msapplication-config" content="https://www.gamingonlinux.com/templates/default/images/favicons/browserconfig.xml">
+<!-- Custom CSS Styles -->
+<link rel="stylesheet" type="text/css" href="https://www.gamingonlinux.com/includes/jscripts/cocoen/css/cocoen.min.css">
+<link rel="preload" href="https://www.gamingonlinux.com/templates/default/css/shipping/style.css?v=1.5.145" as="style" />
+<link rel="stylesheet" href="https://www.gamingonlinux.com/templates/default/css/shipping/style.css?v=1.5.145">
+<link rel="alternate" type="application/rss+xml" title="RSS feed for GamingOnLinux" href="https://www.gamingonlinux.com/article_rss.php" />
+</head>
+
+<body>
+	<div id="cookie_warning">This website makes use of cookies to enhance your browsing experience and provide additional functionality -> <a href="/privacy.html">More info</a> <span class="cookie_action"><span class="badge"><a id="deny_cookies" href="#">Deny Cookies</a></span> - <span class="badge blue"><a id="allow_cookies" href="#">Allow Cookies</a></span></span></div>
+
+	<nav class="navigation-main">
+		<div class="container group">
+			<div class="col-12">
+			<div id="navigation-mobile" class="toggle-nav">
+				<a href="#" onclick="return false;"></a>
+				<div class="toggle-content" id="nav-hidden">
+					<ul>
+						<li><a href="https://www.gamingonlinux.com/index.php?module=login">Login</a></li><li><a href="https://www.gamingonlinux.com/register">Register</a></li>
+						<li><a href="https://www.gamingonlinux.com/mailinglist/">Mailing List</a></li><li><a href="https://www.gamingonlinux.com/users/statistics/">Statistics</a></li><li><a href="https://www.gamingonlinux.com/steam-tracker/">Steam Tracker</a></li><li><a href="https://www.gamingonlinux.com/support-us/">Support Us</a></li>
+						<li><a href="https://www.gamingonlinux.com/steamplay/">Steam Play</a></li>
+						<li><a href="https://www.gamingonlinux.com/search-articles/">Search Articles</a></li>
+						<li><a href="https://www.gamingonlinux.com/free-games/">Free Games</a></li>
+						<li><a href="https://www.gamingonlinux.com/wiki/">Wiki</a></li>
+						<li><a href="https://www.gamingonlinux.com/contact-us/">Contact Us</a></li>
+						<li><a href="https://www.gamingonlinux.com/forum/">Forum</a></li>
+						<li><a href="https://www.gamingonlinux.com/irc/">IRC</a></li>
+						<li><a href="https://discord.gg/AghnYbMjYg">Discord</a></li>
+						<li><a href="https://www.gamingonlinux.com/search-articles/">Search</a></li>
+						<li style="padding:5px;"><div id="theme-slider1" class="theme-slider-container"><div>Theme:</div> <label class="theme-switch">
+							<input type="checkbox">
+							<span class="theme-slider"></span>
+						</label></div></li>
+					</ul>
+				</div>
+			</div>
+			<ul class="header-navbar">
+				<li class="gol-icon"><a href="https://www.gamingonlinux.com/" title="GamingOnLinux Home"><img src="https://www.gamingonlinux.com/templates/default/images/logos/icon.svg" width="35" height="35" alt="GamingOnLinux"></a></li>
+				<li class="nav-title"><a href="https://www.gamingonlinux.com/">GamingOnLinux</a></li>
+				<li class="dropdown hide-small">
+					<a href="#" onclick="return false;">Sections <b class="caret-down"></b></a>
+					<ul class="dropdown-menu">
+						<li><a href="https://www.gamingonlinux.com/mailinglist/">Mailing List</a></li><li><a href="https://www.gamingonlinux.com/users/statistics/">Statistics</a></li><li><a href="https://www.gamingonlinux.com/steam-tracker/">Steam Tracker</a></li><li><a href="https://www.gamingonlinux.com/support-us/">Support Us</a></li>
+						<li><a href="https://www.gamingonlinux.com/steamplay/">Steam Play</a></li>
+						<li><a href="https://www.gamingonlinux.com/search-articles/">Search Articles</a></li>
+						<li><a href="https://www.gamingonlinux.com/free-games/">Free Games</a></li>
+						<li><a href="https://www.gamingonlinux.com/crowdfunders">Crowdfunded Games</a></li>
+						<li><a href="https://www.gamingonlinux.com/wiki/">Wiki</a></li>
+					</ul>
+				</li>
+				<li class="dropdown hide-small">
+					<a href="https://www.gamingonlinux.com/contact-us/">Contact Us <b class="caret-down"></b></a>
+					<ul class="dropdown-menu">
+						<li><a href="https://www.gamingonlinux.com/email-us/">Email Us</a></li>
+
+						<li><a href="https://www.gamingonlinux.com/about-us/">Meet The Team</a></li>
+					</ul>
+				</li>
+				<li class="hide-small"><a href="https://www.gamingonlinux.com/forum/">Forum</a></li>
+				<li class="hide-small"><a href="https://www.gamingonlinux.com/irc/">IRC</a></li>
+				<li class="hide-small"><a href="https://discord.gg/AghnYbMjYg">Discord</a></li>
+			</ul>
+			<div class="right-menu">
+				<div id="search-button-nav" class="toggle-nav search-box">
+					<a href="#"><img src="https://www.gamingonlinux.com/templates/default/images/search.svg" width="12.5" height="12.5" alt="search articles"/></a>
+					<div class="toggle-content">
+							<form method="get" action="https://www.gamingonlinux.com/search-articles/">
+								<input type="text" class="search-field ays-ignore" name="q" placeholder="Search Articles…" />
+								<button type="submit" class="search-button button-primary">Go</button>
+								<input type="submit" style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+							</form>
+					</div>
+				</div>
+
+
+<div class="toggle-nav user-box hide-small">
+	<a href="/index.php?module=login"><div class="avatar-container"><div id="nav-avatar"><img src="https://www.gamingonlinux.com/templates/default/images/blank_user.svg" alt="Login" /></div></div></a>
+	<div class="toggle-content">
+		<ul>
+			<li><a href="https://www.gamingonlinux.com/index.php?module=login">Login</a></li>
+			<li class="divider"></li>
+			<li><a href="https://www.gamingonlinux.com/register/">Register</a></li>
+			<li class="divider"></li>
+			<li style="padding:5px;"><div id="theme-slider2" class="theme-slider-container"><div>Theme:</div> <label class="theme-switch">
+				<input type="checkbox">
+				<span class="theme-slider"></span>
+			</label></div></li>
+		</ul>
+	</div>
+</div>
+
+			</div>
+			<ul class="header-navbar fright">
+				<li class="header-search">
+					<form method="get" action="https://www.gamingonlinux.com/search-articles/">
+					<input type="text" class="search-field ays-ignore" name="q" placeholder="Search Articles…" />
+					<input type="submit" style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+					</form>
+				</li>
+			</ul>
+		</div>
+	</div>
+	</nav>
+	<div id="body" class="smooth group">
+
+<div class="container">
+	<div class="col-12">
+		<div class="multiple-featured-container">
+			<a class="multiple-featured-big" href="https://www.gamingonlinux.com/2022/06/teenage-mutant-ninja-turtles-shredders-revenge-is-out-now/"><div class="overlay"></div><picture><source srcset="https://www.gamingonlinux.com/uploads/carousel/1567681182id21177gol.webp" type="image/webp"><source srcset="https://www.gamingonlinux.com/uploads/carousel/1567681182id21177gol.jpg" type="image/jpeg"><img src="https://www.gamingonlinux.com/uploads/carousel/1567681182id21177gol.jpg" alt="Teenage Mutant Ninja Turtles: Shredder's Revenge"></picture><div class="featured-title"><div class="featured-title-text">Dudes! Beat 'em up Teenage Mutant Ninja Turtles: Shredder's Revenge is out now</div></div></a>
+			<a class="multiple-featured-littletop hide-small" href="https://www.gamingonlinux.com/2022/06/3500-games-now-steam-deck-verified-or-playable/"><div class="overlay"></div><picture><source srcset="https://www.gamingonlinux.com/uploads/carousel/606245493id21195gol.webp" type="image/webp"><source srcset="https://www.gamingonlinux.com/uploads/carousel/606245493id21195gol.jpg" type="image/jpeg"><img src="https://www.gamingonlinux.com/uploads/carousel/606245493id21195gol.jpg" alt="Steam Deck Verified"></picture><div class="featured-title"><div class="featured-title-text">3,500 games now Steam Deck Verified or Playable</div></div></a>
+			<a class="multiple-featured-littlebottom hide-small" href="https://www.gamingonlinux.com/2022/06/inscryption-from-daniel-mullins-games-now-supported-on-linux/"><div class="overlay"></div><picture><source srcset="https://www.gamingonlinux.com/uploads/carousel/2001972571id21209gol.webp" type="image/webp"><source srcset="https://www.gamingonlinux.com/uploads/carousel/2001972571id21209gol.jpg" type="image/jpeg"><img src="https://www.gamingonlinux.com/uploads/carousel/2001972571id21209gol.jpg" alt="Inscryption screenshot"></picture><div class="featured-title"><div class="featured-title-text">Inscryption from Daniel Mullins Games now supported on Linux</div></div></a>
+		</div>
+	</div>
+</div>
+
+<div class="container gol_twitch">
+	<div class="col-12">
+		<div class="box">
+			<div class="body group announce twitch_announce">
+				<span class="fright"><a href="#" class="remove_announce" title="Hide Announcement" data-announce-id="gol_twitch" data-days="1">&#10799;</a></span>
+				<a href="https://www.twitch.tv/gamingonlinux" target="_blank">We're live now on Twitch!</a> <span class="twitch_game"></span>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="container">
+	<div class="col-12">
+		<div class="box">
+
+			<div class="body group announce">
+				<span class="fright"><a href="#" class="remove_announce" title="Hide Announcement" data-announce-id="33">&#10799;</a></span>
+				Join us on our own very special Reddit on <a href="https://www.reddit.com/r/Linuxers/">/r/Linuxers</a>.
+			</div>
+
+		</div>
+	</div>
+</div>
+
+		<div id="content" class="container group">
+			<div class="articles col-9">
+
+				<div class="box" style="margin: 0;">
+					<div class="head"><h1>Latest Articles  - Page: 2</h1>
+						<div class="rss-home gol-share-button rss fright">
+							<a href="/article_rss.php" target="_blank">
+								<img src="/templates/default/images/network-icons/white/rss.svg" alt="RSS Feed" />
+							</a>
+						</div>
+
+
+<div class="toggle-nav fright">
+	<div class="quick-tags">Go to: <a class="link_button" href="/all-articles/">All News</a>  <a class="link_button" href="https://www.gamingonlinux.com/articles/category/Editorial">Editorial</a>  <a class="link_button" href="https://www.gamingonlinux.com/articles/category/Review">Review</a>  <a class="link_button" href="https://www.gamingonlinux.com/articles/category/Interview">Interview</a>  <a class="link_button" href="https://www.gamingonlinux.com/articles/category/HOWTO">HOWTO</a>  </div>
+	<a class="link_button quick-nav-slider" href="#">Quick Tags</a>
+	<div class="toggle-content">
+	<ul><li><a href="/all-articles/">All News</a></li><li><a href="https://www.gamingonlinux.com/articles/category/Editorial">Editorial</a></li><li><a href="https://www.gamingonlinux.com/articles/category/Review">Review</a></li><li><a href="https://www.gamingonlinux.com/articles/category/Interview">Interview</a></li><li><a href="https://www.gamingonlinux.com/articles/category/HOWTO">HOWTO</a></li></ul>
+	</div>
+	</div>
+
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/73-of-the-top-100-most-popular-steam-games-are-playable-on-steam-deck/">
+						<img alt="Steam Deck - Verified and Playable" loading="lazy" height="420" width="740" src="https://www.gamingonlinux.com/uploads/tagline_gallery/deck verified.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/73-of-the-top-100-most-popular-steam-games-are-playable-on-steam-deck/">73 of the top 100 most popular Steam games are playable on Steam Deck</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-30T11:08:17+00:00">6 days ago</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/73-of-the-top-100-most-popular-steam-games-are-playable-on-steam-deck/#comments">24</a></div></div>
+						<div class="desc p-summary">It's been a little while since checking how well the top 100 most played games on Steam work on Linux and the Steam Deck, so here's a fresh run over the list for you. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Editorial">Editorial</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Listicle">Listicle</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Meta">Meta</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/aokzoe-are-the-latest-to-attempt-a-steam-deck-rival-with-the-aokzoe-a1/">
+						<img class="tagline_image" alt="AOKZOE A1" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/1881190574id21241gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/aokzoe-are-the-latest-to-attempt-a-steam-deck-rival-with-the-aokzoe-a1/">AOKZOE are the latest to attempt a Steam Deck rival with the AOKZOE A1</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-29T11:12:51+00:00">7 days ago</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/aokzoe-are-the-latest-to-attempt-a-steam-deck-rival-with-the-aokzoe-a1/#comments">24</a></div></div>
+						<div class="desc p-summary">AOKZOE will be jumping in the handheld ring with their upcoming AOKZOE A1 AMD Ryzen 7 6800U portable that will offer either Windows 11 or SteamOS to perhaps rival the Steam Deck. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Hardware">Hardware</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Meta">Meta</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/SteamOS">SteamOS</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/some-steam-decks-ship-with-an-x2-ssd-instead-of-an-x4-ssd/">
+						<img alt="Steam Deck" loading="lazy" height="420" width="740" src="https://www.gamingonlinux.com/uploads/tagline_gallery/steam_deck.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/some-steam-decks-ship-with-an-x2-ssd-instead-of-an-x4-ssd/">Some Steam Decks ship with an x2 SSD instead of an x4 SSD</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-29T11:00:56+00:00">29 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/some-steam-decks-ship-with-an-x2-ssd-instead-of-an-x4-ssd/#comments">25</a></div></div>
+						<div class="desc p-summary">Valve made a change to the specifications of the top two versions of the Steam Deck last month, which it seems plenty of people (including me) completely missed. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Hardware">Hardware</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Meta">Meta</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Steam">Steam</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/return-to-monkey-island-gets-a-first-gameplay-trailer/">
+						<img class="tagline_image" alt="Return to Monkey Island screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/663785884id21239gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/return-to-monkey-island-gets-a-first-gameplay-trailer/">Return to Monkey Island gets a first gameplay trailer</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T13:06:17+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/return-to-monkey-island-gets-a-first-gameplay-trailer/#comments">45</a></div></div>
+						<div class="desc p-summary">Return to Monkey Island, the continuation of the story from he Secret of Monkey Island and Monkey Island 2: LeChuck’s Revenge now has a first gameplay trailer. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Adventure">Adventure</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Indie_Game">Indie Game</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Point_%26_Click">Point & Click</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Steam">Steam</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/elementallis-is-an-upcoming-zelda-like-adventure-with-elemental-magic-gameplay/">
+						<img class="tagline_image" alt="Elementallis screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/958347608id21238gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/elementallis-is-an-upcoming-zelda-like-adventure-with-elemental-magic-gameplay/">Elementallis is an upcoming Zelda-like adventure with elemental magic gameplay</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T12:06:34+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/elementallis-is-an-upcoming-zelda-like-adventure-with-elemental-magic-gameplay/#comments">2</a></div></div>
+						<div class="desc p-summary">Love your classic Zelda-like adventures? Elementallis looks like a great one to keep an eye on with some interesting elemental magic involved. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Native_Linux">Native Linux</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Action">Action</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Adventure">Adventure</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Demo">Demo</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/pocket-wheels-looks-like-a-fun-toy-car-playground-that-will-support-linux/">
+						<img class="tagline_image" alt="Pocket Wheels screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/2018394241id21237gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/pocket-wheels-looks-like-a-fun-toy-car-playground-that-will-support-linux/">Pocket Wheels looks like a fun toy-car playground that will support Linux</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T10:36:12+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/pocket-wheels-looks-like-a-fun-toy-car-playground-that-will-support-linux/#comments">7</a></div></div>
+						<div class="desc p-summary">Pocket Wheels looks like what you could imagine in your mind when playing with toy cars as a child and it's on the way to Linux with Native support. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Native_Linux">Native Linux</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Indie_Game">Indie Game</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Platformer">Platformer</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Racing">Racing</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/onsen-master-blends-overcooked-with-spirited-away-and-releases-soon/">
+						<img class="tagline_image" alt="Onsen Master screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/617079278id21236gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/onsen-master-blends-overcooked-with-spirited-away-and-releases-soon/">Onsen Master blends Overcooked with Spirited Away and releases soon</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T10:28:29+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/onsen-master-blends-overcooked-with-spirited-away-and-releases-soon/#comments">6</a></div></div>
+						<div class="desc p-summary">Blending the frantic action from the Overcooked series with inspiration taken from Studio Ghibli film Spirited Away, the upcoming Linux Native game Onsen Master looks like fun. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Native_Linux">Native Linux</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Action">Action</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Arcade">Arcade</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Indie_Game">Indie Game</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/fech-the-ferret-is-an-upcoming-vibrant-parkour-rhythm-platformer/">
+						<img class="tagline_image" alt="Fech The Ferret screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/600499617id21235gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/fech-the-ferret-is-an-upcoming-vibrant-parkour-rhythm-platformer/">Fech The Ferret is an upcoming vibrant parkour rhythm-platformer</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T09:33:59+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/fech-the-ferret-is-an-upcoming-vibrant-parkour-rhythm-platformer/#comments">3</a></div></div>
+						<div class="desc p-summary">Love your musical games and want to get into the rhythm? Fech The Ferret looks like a pretty clever blending of ideas. </div>
+						<div class="tags">
+							<ul>
+								 <li class="ea"><a href="https://www.gamingonlinux.com/articles/category/Early_Access">Early Access</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Native_Linux">Native Linux</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Demo">Demo</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Indie_Game">Indie Game</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/steam-deck-gets-a-set-of-nice-bug-fixes-in-a-new-client-update/">
+						<img class="tagline_image" alt="Steam Deck bug fixes" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/2044849124id21234gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/steam-deck-gets-a-set-of-nice-bug-fixes-in-a-new-client-update/">Steam Deck gets a set of nice bug fixes in a new client update</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-28T09:05:45+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/steam-deck-gets-a-set-of-nice-bug-fixes-in-a-new-client-update/#comments">12</a></div></div>
+						<div class="desc p-summary">A fresh Steam Deck Client Update is out now pulling in some rather useful sounding bug fixes, here's what's changed. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Meta">Meta</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Steam">Steam</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Valve">Valve</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/update-pc-info-202206/">
+						<img alt="GOL Tux Logo" loading="lazy" height="420" width="740" src="https://www.gamingonlinux.com/uploads/tagline_gallery/defaulttagline.png">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/update-pc-info-202206/">Reminder: Update your PC info for the next round of statistics updates</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/1844">gamingonlinux</a></strong>, <span class="dt-published"><time datetime="2022-06-28T08:55:17+00:00">28 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/update-pc-info-202206/#comments">5</a></div></div>
+						<div class="desc p-summary">This is your once a month reminder to make sure your PC information is correct on your user profiles. A fresh batch of statistics is generated on the 1st of each month. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Site_Info">Site Info</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Survey">Survey</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/valve-to-ship-more-than-double-the-number-of-steam-decks-each-week/">
+						<img class="tagline_image" alt="Steam Deck delivery emails" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/484846740id21233gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/valve-to-ship-more-than-double-the-number-of-steam-decks-each-week/">Valve to ship 'more than double' the number of Steam Decks each week</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-27T16:38:42+00:00">27 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/valve-to-ship-more-than-double-the-number-of-steam-decks-each-week/#comments">22</a></div></div>
+						<div class="desc p-summary">As we say goodbye to Q2 and hello to Q3, Valve has confirmed that production of Steam Deck units has increased to the point where they're going to be sending out a lot more. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Hardware">Hardware</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Meta">Meta</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Steam">Steam</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+				<!-- Article -->
+				<div class="article group h-entry">
+					<div class="image">
+					<a href="https://www.gamingonlinux.com/2022/06/kingdoms-and-castles-gets-steam-deck-and-gamepad-support-vr-version-coming/">
+						<img class="tagline_image" alt="Kingdoms and Castles screenshot" height="420" width="740" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/1185753265id21231gol.jpg">
+					</a>
+					</div>
+					<div class="info group">
+						<h2 class="title p-name"><a class="u-url" href="https://www.gamingonlinux.com/2022/06/kingdoms-and-castles-gets-steam-deck-and-gamepad-support-vr-version-coming/">Kingdoms and Castles gets Steam Deck and gamepad support, VR version coming</a></h2>
+						<div class="meta">By <strong class="p-author h-card"><a href="https://www.gamingonlinux.com/profiles/liamd">Liam Dawe</a></strong>, <span class="dt-published"><time datetime="2022-06-27T15:42:56+00:00">27 Jun</time></span><div class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/kingdoms-and-castles-gets-steam-deck-and-gamepad-support-vr-version-coming/#comments">4</a></div></div>
+						<div class="desc p-summary">A little castle building and AI conquering on the go? Kingdoms and Castles already worked great on Linux with the Native version and now it should be great on the Steam Deck too. </div>
+						<div class="tags">
+							<ul>
+								 <li ><a href="https://www.gamingonlinux.com/articles/category/Native_Linux">Native Linux</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Steam_Deck">Steam Deck</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/City_Builder">City Builder</a></li>  <li ><a href="https://www.gamingonlinux.com/articles/category/Indie_Game">Indie Game</a></li>
+							</ul>
+						</div>
+					</div>
+				</div>
+
+	<div class="clearer"> </div>
+	<div class="fnone pagination"><a class="live" data-page="1" href="/home/page=1">&laquo;</a><a class="active" href="#">2</a><a class="seperator" href="#">/</a><a class="live" data-page="971" href="/home/page=971">971</a><a class="live" data-page="3" href="/home/page=3">&raquo;</a></div>
+
+			<!-- end content column -->
+			</div>
+
+	<!-- Sidebar -->
+			<div class="col-3">
+
+
+				<div class="support_us_button"><a href="https://www.gamingonlinux.com/support-us/" target="_blank">★ Support Us</a></div>
+
+				<!-- Articles Sidebar -->
+				<div class="box">
+					<div class="head">Popular this week</div>
+					<div class="body list">
+						<ul>
+							<li class="list-group-item"><a href="https://www.gamingonlinux.com/2022/07/linux-share-on-steam-hits-highest-peak-in-years-thanks-to-steam-deck/">Linux share on Steam hits highest peak in years thanks to Steam Deck</a></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/2022/07/gog-finally-remove-the-false-qin-progressq-note-about-gog-galaxy-for-linux/">GOG finally remove the false "in progress" note about GOG Galaxy for Linux</a></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/2022/06/some-steam-decks-ship-with-an-x2-ssd-instead-of-an-x4-ssd/">Some Steam Decks ship with an x2 SSD instead of an x4 SSD</a></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/2022/06/73-of-the-top-100-most-popular-steam-games-are-playable-on-steam-deck/">73 of the top 100 most popular Steam games are playable on Steam Deck</a></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/2022/07/desktopia-is-a-city-builder-that-runs-along-the-bottom-of-your-desktop/">Desktopia is a city-builder that runs along the bottom of your desktop</a></li>
+						</ul>
+					</div>
+					<div class="subhead"><a href="https://www.gamingonlinux.com/search-articles/">Search or view by category</a></div>
+					<div class="head">Contact</div>
+					<div class="body list">
+					<ul>
+						<li><a href="/email-us/">Email Us</a></li>
+
+					</ul>
+					</div>
+				</div>
+
+				<!-- Comments Sidebar -->
+				<div class="box">
+					<div class="head">Latest Comments</div>
+					<div class="body list">
+						<ul class="list-group">
+							<li class="list-group-item">
+	<a href="https://www.gamingonlinux.com/2022/07/13-years-ago-we-appeared-online-happy-birthday-to-gamingonlinux/comment_id=228744">13 years ago we appeared online, Happy Birthday to Gami&hellip;</a><br />
+	<small><time class="timeago" datetime="2022-07-06T10:23:32Z">48 minutes ago</time> - Quill</small>
+</li><li class="list-group-item">
+	<a href="https://www.gamingonlinux.com/2022/07/denuvo-announced-denuvo-securedlc-to-protect-dlc/comment_id=228743">Denuvo announced Denuvo SecureDLC to protect DLC</a><br />
+	<small><time class="timeago" datetime="2022-07-06T10:13:27Z">58 minutes ago</time> - Pit</small>
+</li><li class="list-group-item">
+	<a href="https://www.gamingonlinux.com/2022/07/worthy-of-better-stronger-together-for-reproductive-rights-bundle-live-on-itchio/comment_id=228742">Worthy of Better, Stronger Together for Reproductive Ri&hellip;</a><br />
+	<small><time class="timeago" datetime="2022-07-06T10:12:42Z">59 minutes ago</time> - Cyril</small>
+</li><li class="list-group-item">
+	<a href="https://www.gamingonlinux.com/2022/07/humble-choice-has-deep-rock-galactic-this-month/comment_id=228741">Humble Choice has Deep Rock Galactic this month</a><br />
+	<small><time class="timeago" datetime="2022-07-06T10:01:50Z">1 hour ago</time> - Termy</small>
+</li><li class="list-group-item">
+	<a href="https://www.gamingonlinux.com/2022/07/humble-choice-has-deep-rock-galactic-this-month/comment_id=228740">Humble Choice has Deep Rock Galactic this month</a><br />
+	<small><time class="timeago" datetime="2022-07-06T09:46:36Z">1 hour ago</time> - Corben</small>
+</li>
+							<li><a href="/latest-comments">See more comments</a></li>
+						</ul>
+					</div>
+				</div>
+
+				<!-- Forum Posts Sidebar -->
+				<div class="box">
+					<div class="head">Latest Forum Posts</div>
+					<div class="body list">
+						<ul class="list-group">
+							<li class="list-group-item"><a href="https://www.gamingonlinux.com/forum/topic/5346/post_id=36108">Game not saving</a><br />
+			<small><time datetime="2022-07-06T10:59:20">12 minutes ago</time> - shayan99999</small></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/forum/topic/302/post_id=36107">A New Game Screenshots Thread</a><br />
+			<small><time datetime="2022-07-06T06:38:08">about 5 hours ago</time> - dvd</small></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/forum/topic/5339/post_id=36105">Mass Effect: Legendary Edition errors</a><br />
+			<small><time datetime="2022-07-05T20:02:32">about 15 hours ago</time> - Grogan</small></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/forum/topic/5347/post_id=36102">Use Linux on a computer with a PowerPC processor</a><br />
+			<small><time datetime="2022-07-05T18:57:04">about 16 hours ago</time> - darcksama</small></li><li class="list-group-item"><a href="https://www.gamingonlinux.com/forum/topic/5341/post_id=36103">Weekend Play List 7/1/22</a><br />
+			<small><time datetime="2022-07-05T18:13:51">about 17 hours ago</time> - Pengling</small></li>
+							<li><a href="/forum/">See more posts</a></li>
+						</ul>
+					</div>
+				</div>
+
+				<!-- Misc Links & Stuff -->
+				<div class="box">
+					<div class="head">Misc</div>
+					<div class="body list">
+					<ul>
+						<li><a href="/index.php?module=cookie_prefs">Cookie Preferences</a></li>
+						<li><a href="/support-us/">Support Us</a></li>
+						<li><a href="/about-us/">About Us</a></li>
+						<li><a href="https://www.gamingonlinux.com/index.php?module=website_stats">Website Statistics</a></li>
+					</ul>
+					</div>
+				</div>
+
+
+				<div class="gamesdbbutton"><a href="/free-games/" target="_blank">Free Linux Games</a></div>
+
+			</div>
+		</div>
+
+<div class="container">
+	<div class="col-12">
+		<div class="box">
+			<div class="header-text-plain bigger">Hot Articles Over The Last 30 Days</div>
+			<div class="box footer-articles">
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/arctic-awakening-is-an-upcoming-cold-narrative-adventure-mystery/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/507493151id21159gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/arctic-awakening-is-an-upcoming-cold-narrative-adventure-mystery/">Arctic Awakening is an upcoming cold narrative-adventure mystery</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/arctic-awakening-is-an-upcoming-cold-narrative-adventure-mystery/#comments">0</a></span></div>
+					</div>
+			</article>
+			<div class="footer-grid-seperator"></div>
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/proton-experimental-sees-fixes-for-persona-4-golden-final-fantasy-xiv-black-ops/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/362844140id21245gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/proton-experimental-sees-fixes-for-persona-4-golden-final-fantasy-xiv-black-ops/">Proton Experimental sees fixes for Persona 4 Golden, Final Fantasy XIV, Black Ops II</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/proton-experimental-sees-fixes-for-persona-4-golden-final-fantasy-xiv-black-ops/#comments">5</a></span></div>
+					</div>
+			</article>
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/steam-deck-back-to-being-the-global-top-seller-by-revenue-on-steam/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/974239618id21189gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/steam-deck-back-to-being-the-global-top-seller-by-revenue-on-steam/">Steam Deck back to being the global top seller (by revenue) on Steam</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/steam-deck-back-to-being-the-global-top-seller-by-revenue-on-steam/#comments">11</a></span></div>
+					</div>
+			</article>
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/usagi-shima-is-an-idle-bunny-collecting-game-that-i-simply-need/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/1984315039id21150gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/usagi-shima-is-an-idle-bunny-collecting-game-that-i-simply-need/">Usagi Shima is an idle bunny collecting game that I simply need</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/usagi-shima-is-an-idle-bunny-collecting-game-that-i-simply-need/#comments">6</a></span></div>
+					</div>
+			</article>
+
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="container">
+	<div class="col-12">
+		<div class="box">
+			<div class="header-text-plain bigger">Recent Linux Distribution and Open Source News</div>
+			<div class="box footer-articles">
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/westwood-classic-rpg-nox-lives-on-with-the-opennox-game-engine/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/1978466232id21194gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/westwood-classic-rpg-nox-lives-on-with-the-opennox-game-engine/">Westwood classic RPG 'Nox' lives on with the OpenNox game engine</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/westwood-classic-rpg-nox-lives-on-with-the-opennox-game-engine/#comments">20</a></span></div>
+					</div>
+			</article>
+			<div class="footer-grid-seperator"></div>
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/kde-plasma-525-is-out-now-heres-some-of-whats-new/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/195440564id21163gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/kde-plasma-525-is-out-now-heres-some-of-whats-new/">KDE Plasma 5.25 is out now, here's some of what's new</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/kde-plasma-525-is-out-now-heres-some-of-whats-new/#comments">61</a></span></div>
+					</div>
+			</article>
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/heroes-of-might-and-magic-ii-reimplementation-gets-big-audio-improvements-and-ai-speedup/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/455914169id21191gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/heroes-of-might-and-magic-ii-reimplementation-gets-big-audio-improvements-and-ai-speedup/">Heroes of Might and Magic II reimplementation gets big audio improvements and AI speedup</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/heroes-of-might-and-magic-ii-reimplementation-gets-big-audio-improvements-and-ai-speedup/#comments">3</a></span></div>
+					</div>
+			</article>
+
+			<article class="footer-article-flex-col-item">
+					<div class="footer-article-image">
+						<a href="https://www.gamingonlinux.com/2022/06/microphone-noise-suppression-app-noisetorch-returns-with-a-new-release/"><img class="tagline_image" alt="" height="142" width="250" loading="lazy" src="https://www.gamingonlinux.com/uploads/articles/tagline_images/2121918628id21151gol.jpg"></a>
+					</div>
+						<div class="footer-article-title"><a href="https://www.gamingonlinux.com/2022/06/microphone-noise-suppression-app-noisetorch-returns-with-a-new-release/">Microphone noise suppression app NoiseTorch returns with a new release</a><div class="footer-article-meta">by <a href="/profiles/liamd">Liam Dawe</a> <span class="comments-pip"><a href="https://www.gamingonlinux.com/2022/06/microphone-noise-suppression-app-noisetorch-returns-with-a-new-release/#comments">13</a></span></div>
+					</div>
+			</article>
+
+			</div>
+		</div>
+	</div>
+</div>
+
+</div>
+<footer id="footer" class="group smooth grid">
+	<div id="footer-wrapper" class="row">
+		<div class="container">
+			<div id="social" class="col-6">
+				<div class="box footer-header">Join us</div>
+				<ul>
+					<li><a title="Twitter" class="tooltip-top" href="https://www.twitter.com/gamingonlinux" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux twitter" src="/templates/default/images/network-icons/white/twitter.svg" width="30" height="30" /></a></li>
+					<li><a title="Telegram" class="tooltip-top" href="https://t.me/linux_gaming" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux telegram" src="/templates/default/images/network-icons/white/telegram.svg" width="30" height="30" /></a></li>
+					<li><a title="Discord" class="tooltip-top" href="https://discord.gg/AghnYbMjYg" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinx discord" src="/templates/default/images/network-icons/white/discord.svg" width="30" height="30" /></a></li>
+					<li><a title="Matrix" class="tooltip-top" href="https://matrix.to/#/#gamingonlinux-community:matrix.org" rel="noopener noreferrer" target="_blank"><img alt="matrix" src="/templates/default/images/network-icons/white/matrix.svg" width="30" height="30" /></a></li>
+					<li><a title="Steam Community" class="tooltip-top" href="https://steamcommunity.com/groups/gamingonlinux" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux steam" src="/templates/default/images/network-icons/white/steam.svg" width="30" height="30" /></a></li>
+					<li><a title="Twitch" class="tooltip-top" href="https://www.twitch.tv/gamingonlinux" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux twitch" src="/templates/default/images/network-icons/white/twitch.svg" width="30" height="30" /></a></li>
+					<li><a title="Youtube" class="tooltip-top" href="https://www.youtube.com/user/GamingOnLinuxcom" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux youtube" src="/templates/default/images/network-icons/white/youtube.svg" width="30" height="30" /></a></li>
+					<li><a title="Facebook" class="tooltip-top" href="https://www.facebook.com/gamingonlinux" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux facebook" src="/templates/default/images/network-icons/white/facebook.svg" width="30" height="30" /></a></li>
+					<li><a rel="me" title="Mastodon" class="tooltip-top" href="https://mastodon.social/@gamingonlinux" rel="noopener noreferrer" target="_blank"><img alt="gamingonlinux mastodon" src="/templates/default/images/network-icons/white/mastodon.svg" width="30" height="30" /></a></li>
+				</ul>
+				<div class="box footer-header">RSS Feeds</div>
+				<ul>
+					<li><a title="Article RSS feed" class="tooltip-top" href="https://www.gamingonlinux.com/article_rss.php" target="_blank"><img alt="Main RSS Feed" src="https://www.gamingonlinux.com/templates/default/images/network-icons/white/rss-website.svg" width="30" height="30" /></a></li>
+					<li><a title="Forum RSS" class="tooltip-top" href="https://www.gamingonlinux.com/forum_rss.php" target="_blank"><img alt="Forum RSS Feed" src="https://www.gamingonlinux.com/templates/default/images/network-icons/white/rss-forum.svg" width="30" height="30" /></a></li>
+				</ul>
+			</div>
+			<div id="about" class="col-6">
+				<div class="col-10">
+				<a href="https://www.gamingonlinux.com/">GamingOnLinux &copy; 2022</a><br />
+				<br />
+                Unless otherwise noted, our articles are licensed as: <br />
+				<a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="noopener noreferrer">CC BY-SA 4.0</a><br />
+				<br />
+				<a href="/about-us/">About Us</a>, <a href="/email-us/">Contact Us</a>, <a href="https://www.gamingonlinux.com/privacy.html">Privacy</a>, <a href="https://www.gamingonlinux.com/ethics.html">Ethics</a></div>
+				<div class="col-2">
+					<img src="/templates/default/images/logos/icon.svg" width="100" alt="logo" /></div>
+			</div>
+		</div>
+	</div>
+</footer>
+<script src="https://www.gamingonlinux.com/includes/jscripts/GOL/header.min.js?v=2.4"></script>
+<script src="https://www.gamingonlinux.com/includes/jscripts/GOL/twitch_checker.js?v=4"></script>
+<script src="https://www.gamingonlinux.com/includes/jscripts/jquery.are-you-sure.js"></script>
+<script>twitch_check(); setInterval ( "twitch_check()", 60000 );</script>
+<link rel="stylesheet" type="text/css" href="https://www.gamingonlinux.com/includes/jscripts/select2/css/select2.min.css">
+<script src="https://www.gamingonlinux.com/includes/jscripts/select2/js/select2.min.js?v=4"></script>
+<!-- fancybox for images -->
+<link rel="stylesheet" href="https://www.gamingonlinux.com/includes/jscripts/fancybox/jquery.fancybox.css?v=3" type="text/css" media="screen" />
+<script src="https://www.gamingonlinux.com/includes/jscripts/fancybox/jquery.fancybox.min.js?v=3"></script>
+<link rel="stylesheet" href="https://www.gamingonlinux.com/includes/jscripts/autocomplete/easy-autocomplete.min.css">
+<script src="https://www.gamingonlinux.com/includes/jscripts/autocomplete/jquery.easy-autocomplete.min.js"></script>
+<script>
+	var sale_search_options = {
+		url: function(phrase) {
+				return "/includes/ajax/gamesdb/search_games.php?return_type=text&q=" + phrase + "&type=sales&format=json";
+		},
+
+		getValue: "data",
+		adjustWidth: false,
+
+		ajaxSettings: {
+			dataType: "json"
+		},
+		requestDelay: 300,
+		list: {
+			onClickEvent: function() {
+				var replaced = $("#sale-search").val().replace(/ /g, '+');
+			}
+		}
+	};
+
+	var free_search_options = {
+		url: function(phrase) {
+				return "/includes/ajax/gamesdb/search_games.php?return_type=text&q=" + phrase + "&type=free&format=json";
+		},
+
+		getValue: "data",
+		adjustWidth: false,
+
+		ajaxSettings: {
+			dataType: "json"
+		},
+		requestDelay: 300,
+		list: {
+			onClickEvent: function() {
+				var replaced = $("#free-search").val().replace(/ /g, '+');
+			}
+		}
+	};
+
+	var all_search_options = {
+		url: function(phrase) {
+				return "/includes/ajax/gamesdb/search_games.php?return_type=text&q=" + phrase + "&type=all&format=json";
+		},
+
+		getValue: "data",
+		adjustWidth: false,
+
+		ajaxSettings: {
+			dataType: "json"
+		},
+		requestDelay: 300,
+		list: {
+			onClickEvent: function() {
+				var replaced = $("#all-games-search").val().replace(/ /g, '+');
+			}
+		}
+	};
+
+$("#sale-search").easyAutocomplete(sale_search_options);
+$("#free-search").easyAutocomplete(free_search_options);
+$("#all-games-search").easyAutocomplete(all_search_options);
+
+// keep session alive for CSRF tokens
+var refreshSn = function ()
+{
+    var time = 300000; // 5 mins, milliseconds
+    setTimeout(
+        function ()
+        {
+        $.ajax({
+           url: '/includes/ajax/refresh_session.php',
+           cache: false,
+           complete: function () {refreshSn();}
+        });
+    },
+    time
+	);
+};
+refreshSn()
+</script>
+<script src="https://www.gamingonlinux.com/includes/jscripts/sorttable.min.js"></script>
+<script src="https://www.gamingonlinux.com/includes/jscripts/clipboard/clipboard.min.js"></script>
+
+
+</body>
+</html>

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -61,6 +61,28 @@ class TestGetArticles:
         ):
             next(services.get_articles())
 
+    def test_handles_spaces_in_image_url(
+        self, page_url: str, requests_mock: Mocker
+    ) -> None:
+        """
+        Given: that the web returns an html with an article that has a space in the url
+        When: using get_articles
+        Then: the image link is transformed so it doesn't raise a ValidationError
+        """
+        with open(
+            "tests/assets/homepage-with-space-in-article-image-url.html",
+            "r",
+            encoding="UTF8",
+        ) as file_descriptor:
+            requests_mock.get(page_url, text=file_descriptor.read())
+
+        result = next(services.get_articles())
+
+        assert str(result.image) == (
+            "https://www.gamingonlinux.com/uploads/tagline_gallery/"
+            "deck%20verified.jpg"
+        )
+
 
 class TestGetArticleContent:
     """Test the fetch of the article content."""


### PR DESCRIPTION
fix: correct the published date of the articles

`created_at` was used, which was misleading if the creation of the feed
was done after the article published date.

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
